### PR TITLE
alpine-slim replaced with alpine base

### DIFF
--- a/android-21/Dockerfile
+++ b/android-21/Dockerfile
@@ -1,5 +1,5 @@
-FROM alvrme/alpine-android-base
-LABEL maintainer="Álvaro S. <alvaro@alvr.me>"
+FROM tenrero/android-alpine-base
+LABEL maintainer="Marcos Tenrero"
 
 ENV BUILD_TOOLS "21.1.2"
 ENV TARGET_SDK "21"

--- a/android-22/Dockerfile
+++ b/android-22/Dockerfile
@@ -1,5 +1,5 @@
-FROM alvrme/alpine-android-base
-LABEL maintainer="Álvaro S. <alvaro@alvr.me>"
+FROM tenrero/android-alpine-base
+LABEL maintainer="Marcos Tenrero"
 
 ENV BUILD_TOOLS "22.0.1"
 ENV TARGET_SDK "22"

--- a/android-23/Dockerfile
+++ b/android-23/Dockerfile
@@ -1,5 +1,5 @@
-FROM alvrme/alpine-android-base
-LABEL maintainer="Álvaro S. <alvaro@alvr.me>"
+FROM tenrero/android-alpine-base
+LABEL maintainer="Marcos Tenrero"
 
 ENV BUILD_TOOLS "23.0.3"
 ENV TARGET_SDK "23"

--- a/android-24/Dockerfile
+++ b/android-24/Dockerfile
@@ -1,5 +1,5 @@
-FROM alvrme/alpine-android-base
-LABEL maintainer="Álvaro S. <alvaro@alvr.me>"
+FROM tenrero/android-alpine-base
+LABEL maintainer="Marcos Tenrero"
 
 ENV BUILD_TOOLS "24.0.3"
 ENV TARGET_SDK "24"

--- a/android-25/Dockerfile
+++ b/android-25/Dockerfile
@@ -1,5 +1,5 @@
-FROM alvrme/alpine-android-base
-LABEL maintainer="Álvaro S. <alvaro@alvr.me>"
+FROM tenrero/android-alpine-base
+LABEL maintainer="Marcos Tenrero"
 
 ENV BUILD_TOOLS "25.0.3"
 ENV TARGET_SDK "25"

--- a/android-26/Dockerfile
+++ b/android-26/Dockerfile
@@ -1,5 +1,5 @@
-FROM alvrme/alpine-android-base
-LABEL maintainer="Álvaro S. <alvaro@alvr.me>"
+FROM tenrero/android-alpine-base
+LABEL maintainer="Marcos Tenrero"
 
 ENV BUILD_TOOLS "26.0.3"
 ENV TARGET_SDK "26"

--- a/android-27/Dockerfile
+++ b/android-27/Dockerfile
@@ -1,5 +1,5 @@
-FROM alvrme/alpine-android-base
-LABEL maintainer="Álvaro S. <alvaro@alvr.me>"
+FROM tenrero/android-alpine-base
+LABEL maintainer="Marcos Tenrero"
 
 ENV BUILD_TOOLS "27.0.3"
 ENV TARGET_SDK "27"

--- a/android-28/Dockerfile
+++ b/android-28/Dockerfile
@@ -1,5 +1,5 @@
-FROM alvrme/alpine-android-base
-LABEL maintainer="Álvaro S. <alvaro@alvr.me>"
+FROM tenrero/android-alpine-base
+LABEL maintainer="Marcos Tenrero"
 
 ENV BUILD_TOOLS "28.0.3"
 ENV TARGET_SDK "28"

--- a/android-29/Dockerfile
+++ b/android-29/Dockerfile
@@ -1,5 +1,5 @@
-FROM alvrme/alpine-android-base
-LABEL maintainer="Álvaro S. <alvaro@alvr.me>"
+FROM tenrero/android-alpine-base
+LABEL maintainer="Marcos Tenrero"
 
 ENV BUILD_TOOLS "29.0.2"
 ENV TARGET_SDK "29"

--- a/android-base/Dockerfile
+++ b/android-base/Dockerfile
@@ -1,5 +1,5 @@
 FROM adoptopenjdk/openjdk8:alpine
-LABEL maintainer="Álvaro S. <alvaro@alvr.me>"
+LABEL maintainer="Marcos Tenrero"
 
 ENV SDK_TOOLS "4333796"
 ENV ANDROID_HOME "/opt/sdk"

--- a/android-base/Dockerfile
+++ b/android-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk8:alpine-slim
+FROM adoptopenjdk/openjdk8:alpine
 LABEL maintainer="Álvaro S. <alvaro@alvr.me>"
 
 ENV SDK_TOOLS "4333796"

--- a/android-base/README.md
+++ b/android-base/README.md
@@ -18,7 +18,7 @@
 In your Dockerfile use
 
 ```dockerfile
-FROM alvrme/alpine-android-base
+FROM tenrero/android-alpine-base
 ```
 
 this will install the packages above.


### PR DESCRIPTION
Replaced adoptopenjdk alpine slim version with alpine base version as the slim version doesn't have some required binaries for signing the application like jarsigner. 

You can check the binaries removal in the following link: [https://bug.cloverdx.com/browse/CLO-16634](https://bug.cloverdx.com/browse/CLO-16634)