### PR TITLE
Use alpine instead alpine-slime as base image

### DIFF
--- a/android-base/Dockerfile
+++ b/android-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk8:alpine-slim
+FROM adoptopenjdk/openjdk8:alpine
 LABEL maintainer="Álvaro S. <alvaro@alvr.me>"
 
 ENV SDK_TOOLS "4333796"


### PR DESCRIPTION
There are some useful tools that are not included in "slim" version, for example I need a `jarsigner`